### PR TITLE
UPDATE: add gym terminal and gym reward to base

### DIFF
--- a/samples/gym-frozenlake-sample/Dockerfile
+++ b/samples/gym-frozenlake-sample/Dockerfile
@@ -1,0 +1,22 @@
+# this is one of the cached base images available for ACI
+FROM python:3.7.4
+
+# Install libraries and dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    zlib1g-dev \
+    swig
+
+# Set up the simulator
+WORKDIR /src
+
+# Copy simulator files to /src
+COPY . /src
+
+# Install simulator dependencies
+RUN pip3 install -r requirements.txt
+
+# # This will be the command to run the simulator
+CMD ["python3", "main.py"]

--- a/samples/gym-frozenlake-sample/Dockerfile
+++ b/samples/gym-frozenlake-sample/Dockerfile
@@ -19,4 +19,4 @@ COPY . /src
 RUN pip3 install -r requirements.txt
 
 # # This will be the command to run the simulator
-CMD ["python3", "main.py"]
+CMD ["python3", "frozenlake_simulator.py"]

--- a/samples/gym-frozenlake-sample/frozenlake_4x4.ink
+++ b/samples/gym-frozenlake-sample/frozenlake_4x4.ink
@@ -3,7 +3,13 @@ inkling "2.0"
 using Number
 
 type GameState {
-    current_pos: Number.Int8<0 .. 15>
+    current_pos: Number.Int8<0 .. 15>,
+}
+
+type SimState {
+    current_pos: Number.Int8<0 .. 15>,
+    _gym_reward: number,
+    _gym_terminal: Number.Bool
 }
 
 type Action {
@@ -14,13 +20,25 @@ type FrozenLakeConfig {
     deque_size: 1
 }
 
-simulator FrozenlakeSimulator(action: Action, config: FrozenLakeConfig): GameState {
+simulator FrozenlakeSimulator(action: Action, config: FrozenLakeConfig): SimState {
+}
+
+function Reward(State: SimState) {
+
+    return State._gym_reward
+}
+
+function Terminal(State: SimState) {
+
+    return State._gym_terminal
 }
 
 graph (input: GameState): Action {
     concept GoalPosition(input): Action {
         curriculum {
             source FrozenlakeSimulator
+            reward Reward
+            terminal Terminal
         }
     }
     output GoalPosition


### PR DESCRIPTION
Solves #1 for `frozenlake` as a base example.

## Updates

1. `gym_simulator3.episode_start` and `gym_simulator3.episode_step` now return a state dictionary that includes `_gym_reward` and `_gym_terminal`
2. `_set_last_state` appends the rewards and terminals from `sim.step` or sets as default 0 and False for `sim.reset()`
3. Adds `Dockerfile` for sim packaging example
4. Updated Inkling for `frozenlake` with the gym reward and terminals