### PR TITLE
BUGFIX: remove unused arguments of reward and terminal in `gym_to_state`; remove version imports

### DIFF
--- a/bonsai_gym/__init__.py
+++ b/bonsai_gym/__init__.py
@@ -6,4 +6,3 @@ gym as a simulator for Bonsai BRAIN.
 # pyright: reportUnusedImport=false
 
 from .gym_simulator3 import GymSimulator3
-from .version import __version__

--- a/bonsai_gym/gym_simulator3.py
+++ b/bonsai_gym/gym_simulator3.py
@@ -35,7 +35,7 @@ class GymSimulator3(SimulatorSession):
         # store initial gym state
         try:
             # initial reward = 0; initial terminal False
-            state = self.gym_to_state(initial_observation, terminal=False, reward=0)
+            state = self.gym_to_state(initial_observation)
         except NotImplementedError as e:
             raise e
         self._set_last_state(state, 0, False)
@@ -55,9 +55,7 @@ class GymSimulator3(SimulatorSession):
     # These MUST be implemented by the simulator.
     #
 
-    def gym_to_state(
-        self, observation: Any, reward: float, terminal: bool
-    ) -> Dict[str, Any]:
+    def gym_to_state(self, observation: Any) -> Dict[str, Any]:
         """Convert a gym observation into an Inkling state
 
         Example:
@@ -140,7 +138,7 @@ class GymSimulator3(SimulatorSession):
 
         # initial observation
         observation = self.gym_episode_start(config)
-        state = self.gym_to_state(observation, reward=0, terminal=False)
+        state = self.gym_to_state(observation)
         state = self._set_last_state(state, 0, False)
         return state
 
@@ -184,7 +182,7 @@ class GymSimulator3(SimulatorSession):
         self.episode_reward += reward
 
         # convert state and return to the server
-        state = self.gym_to_state(observation, reward=reward, terminal=done)
+        state = self.gym_to_state(observation)
         state = self._set_last_state(state, reward, done)
         return state
 

--- a/samples/gym-acrobot-sample/acrobot.ink
+++ b/samples/gym-acrobot-sample/acrobot.ink
@@ -2,13 +2,23 @@ inkling "2.0"
 
 using Number
 
+function Reward(gs: GameState) {
+    return gs._gym_reward
+}
+
+function Terminal(gs: GameState) {
+    return gs._gym_terminal
+}
+
 type GameState {
     cos_theta0: number,
     sin_theta0: number,
     cos_theta1: number,
     sin_theta1: number,
     theta0_dot: number,
-    theta1_dot: number
+    theta1_dot: number,
+    _gym_reward: number,
+    _gym_terminal: number
 }
 
 type Action {
@@ -24,10 +34,9 @@ simulator AcrobotSimulator(action: Action, config: AcrobotConfig): GameState {
 
 graph (input: GameState): Action {
     concept Height(input): Action {
-        experiment {
-            random_seed: "42"
-        }
         curriculum {
+            reward Reward
+            terminal Terminal
             source AcrobotSimulator
         }
     }

--- a/samples/gym-blackjack-sample/blackjack.ink
+++ b/samples/gym-blackjack-sample/blackjack.ink
@@ -2,10 +2,20 @@ inkling "2.0"
 
 using Number
 
+function Reward(gs: GameState) {
+    return gs._gym_reward
+}
+
+function Terminal(gs: GameState) {
+    return gs._gym_terminal
+}
+
 type GameState {
     current_sum: number<0 .. 31 step 1>,
     dealer_card: number<0 .. 10 step 1>,
-    usable_ace: number<0, 1>
+    usable_ace: number<0, 1>,
+    _gym_reward: number,
+    _gym_terminal: number
 }
 
 type Action {
@@ -23,6 +33,8 @@ simulator blackjack_simulator(action: Action, config: BlackJackConfig): GameStat
 graph (input: GameState): Action {
     concept high_score(input): Action {
         curriculum {
+            reward Reward
+            terminal Terminal
             source blackjack_simulator
         }
     }

--- a/samples/gym-cartpole-sample/cartpole.ink
+++ b/samples/gym-cartpole-sample/cartpole.ink
@@ -27,7 +27,7 @@ type CartPoleConfig {
     deque_size: Number.UInt8
 }
 
-simulator cartpole_simulator(action: Action, config: CartPoleConfig): GameState {
+simulator CartpoleSimulator(action: Action, config: CartPoleConfig): GameState {
 }
 
 graph (input: GameState): Action {
@@ -36,7 +36,7 @@ graph (input: GameState): Action {
         curriculum {
             reward Reward
             terminal Terminal
-            source cartpole_simulator
+            source CartpoleSimulator
             lesson balancing {
                 scenario {
                     episode_length: -1,

--- a/samples/gym-cartpole-sample/cartpole.ink
+++ b/samples/gym-cartpole-sample/cartpole.ink
@@ -1,31 +1,49 @@
 inkling "2.0"
-
 using Number
+
+function Reward(gs: GameState) {
+    return gs._gym_reward
+}
+
+function Terminal(gs: GameState) {
+    return gs._gym_terminal
+}
 
 type GameState {
     position: Number.Float32,
     velocity: Number.Float32,
     angle: Number.Float32,
-    rotation: Number.Float32
+    rotation: Number.Float32,
+    _gym_reward: number,
+    _gym_terminal: number
 }
 
 type Action {
-    command: Number.Int8<Left = 0, Right = 1>
+    command: Number.Int8<Left=0, Right=1>
 }
 
 type CartPoleConfig {
-    episode_length: -1,
-    deque_size: 1
+    episode_length: Number.Int8,
+    deque_size: Number.UInt8
 }
 
-simulator CartpoleSimulator(action: Action, config: CartPoleConfig): GameState {
+simulator cartpole_simulator(action: Action, config: CartPoleConfig): GameState {
 }
 
 graph (input: GameState): Action {
-    concept Balance(input): Action {
+
+    concept balance(input): Action {
         curriculum {
-            source CartpoleSimulator
+            reward Reward
+            terminal Terminal
+            source cartpole_simulator
+            lesson balancing {
+                scenario {
+                    episode_length: -1,
+                    deque_size: 1
+                }
+            }
         }
     }
-    output Balance
+    output balance
 }

--- a/samples/gym-lunarlander-continuous-sample/lunarlander_continuous.ink
+++ b/samples/gym-lunarlander-continuous-sample/lunarlander_continuous.ink
@@ -1,4 +1,18 @@
 inkling "2.0"
+using Number
+
+type SimState{
+    x_position: number,
+    y_position: number,
+    x_velocity: number,
+    y_velocity: number,
+    angle: number,
+    rotation: number,
+    left_leg: number,
+    right_leg: number,
+    _gym_reward: number,
+    _gym_terminal: Number.Bool
+}
 
 type GameState {
     x_position: number,
@@ -10,6 +24,17 @@ type GameState {
     left_leg: number,
     right_leg: number
 }
+
+function Reward(State: SimState) {
+
+    return State._gym_reward
+}
+
+function Terminal(State: SimState) {
+
+    return State._gym_terminal
+}
+
 
 const ThrottleMin = -1.0
 const ThrottleMax = 1.0
@@ -23,13 +48,15 @@ type LunarLanderConfig {
     deque_size: 1
 }
 
-simulator LunarLanderSimulator(action: LanderAction, config: LunarLanderConfig): GameState {
+simulator LunarLanderSimulator(action: LanderAction, config: LunarLanderConfig): SimState {
 }
 
 graph (input: GameState): LanderAction {
     concept Land(input): LanderAction {
         curriculum {
             source LunarLanderSimulator
+            reward Reward
+            terminal Terminal
         }
     }
     output Land

--- a/samples/gym-lunarlander-single-concept-sample/lunarlander_single_concept.ink
+++ b/samples/gym-lunarlander-single-concept-sample/lunarlander_single_concept.ink
@@ -2,6 +2,14 @@ inkling "2.0"
 
 using Number
 
+function Reward(gs: GameState) {
+    return gs._gym_reward
+}
+
+function Terminal(gs: GameState) {
+    return gs._gym_terminal
+}
+
 type GameState {
     x_position: number,
     y_position: number,
@@ -28,6 +36,8 @@ simulator lunarlander_simulator(action: LanderAction, config: LunarLanderConfig)
 graph (input: GameState): LanderAction {
     concept land(input): LanderAction {
         curriculum {
+            reward Reward
+            terminal Terminal
             source lunarlander_simulator
         }
     }

--- a/samples/gym-mountaincar-continuous-sample/mountaincar_continuous.ink
+++ b/samples/gym-mountaincar-continuous-sample/mountaincar_continuous.ink
@@ -4,9 +4,19 @@
 
 inkling "2.0"
 
+function Reward(gs: GameState) {
+    return gs._gym_reward
+}
+
+function Terminal(gs: GameState) {
+    return gs._gym_terminal
+}
+
 type GameState {
     x_position: number,
-    x_velocity: number
+    x_velocity: number,
+    _gym_reward: number,
+    _gym_terminal: number
 }
 
 const ThrottleMin = -1.0
@@ -25,6 +35,8 @@ simulator MountainCarSimulator(action: Action, config: MountainCarConfig): GameS
 graph (input: GameState): Action {
     concept HighScore(input): Action {
         curriculum {
+            reward Reward
+            terminal Terminal
             source MountainCarSimulator
         }
     }

--- a/samples/gym-mountaincar-continuous-sample/mountaincar_continuous.ink
+++ b/samples/gym-mountaincar-continuous-sample/mountaincar_continuous.ink
@@ -1,7 +1,3 @@
-# Inkling code for driving a car up a mountain.
-# Simulator source code:
-# https://github.com/BonsaiAI/bonsai-sdk/blob/master/samples/openai-gym/gym-mountaincar-continuous-sample/mountaincar_continuous_simulator.py
-
 inkling "2.0"
 
 function Reward(gs: GameState) {

--- a/samples/gym-mountaincar-sample/mountaincar.ink
+++ b/samples/gym-mountaincar-sample/mountaincar.ink
@@ -2,9 +2,19 @@ inkling "2.0"
 
 using Number
 
+function Reward(gs: GameState) {
+    return gs._gym_reward
+}
+
+function Terminal(gs: GameState) {
+    return gs._gym_terminal
+}
+
 type GameState {
     x_position: number,
-    x_velocity: number
+    x_velocity: number,
+    _gym_reward: number,
+    _gym_terminal: number
 }
 
 type Action {
@@ -22,6 +32,8 @@ simulator MountainCarSimulator(action: Action, config: MountainCarConfig): GameS
 graph (input: GameState): Action {
     concept HighScore(input): Action {
         curriculum {
+            reward Reward
+            terminal Terminal
             source MountainCarSimulator
         }
     }

--- a/samples/gym-tapecopy-sample/tapecopy.ink
+++ b/samples/gym-tapecopy-sample/tapecopy.ink
@@ -2,8 +2,18 @@ inkling "2.0"
 
 using Number
 
+function Reward(gs: GameState) {
+    return gs._gym_reward
+}
+
+function Terminal(gs: GameState) {
+    return gs._gym_terminal
+}
+
 type GameState {
-    character: Number.Int8<0 .. 5>
+    character: Number.Int8<0 .. 5>,
+    _gym_reward: number,
+    _gym_terminal: number
 }
 
 type Action {
@@ -23,6 +33,8 @@ simulator tapecopy_simulator(action: Action, config: CopyConfig): GameState {
 graph (input: GameState): Action {
     concept copy_string(input): Action {
         curriculum {
+            reward Reward
+            terminal Terminal
             source tapecopy_simulator
         }
     }

--- a/samples/gym-taxi-sample/requirements.txt
+++ b/samples/gym-taxi-sample/requirements.txt
@@ -1,1 +1,2 @@
 git+https://github.com/microsoft/bonsai-gym
+scipy

--- a/samples/gym-taxi-sample/taxi.ink
+++ b/samples/gym-taxi-sample/taxi.ink
@@ -2,8 +2,18 @@ inkling "2.0"
 
 using Number
 
+function Reward(gs: GameState) {
+    return gs._gym_reward
+}
+
+function Terminal(gs: GameState) {
+    return gs._gym_terminal
+}
+
 type GameState {
-    location: Number.Int16<0 .. 499>
+    location: Number.Int16<0 .. 499>,
+    _gym_reward: number,
+    _gym_terminal: number
 }
 
 type Action {
@@ -20,6 +30,8 @@ simulator taxi_simulator(action: Action, config: TaxiConfig): GameState {
 graph (input: GameState): Action {
     concept taxi_service(input): Action {
         curriculum {
+            reward Reward
+            terminal Terminal
             source taxi_simulator
         }
     }


### PR DESCRIPTION
* Bugfix: previous PR introduced reward and terminal arguments to `gym_to_state`, which was not implemented in methods inherited in the samples. It also seems redundant, as `set_last_state` adds the reward and terminal to the default attribute `_gym_reward` and `_gym_terminal` respectively
* Bugfix: remove import of version from non-existent `version.py`

PR Soundtrack: [teef teef](https://www.youtube.com/watch?v=uPo6e6T5ibw&ab_channel=Juls-Topic)